### PR TITLE
Replace `queue` key with `name`

### DIFF
--- a/src/Queue/CreateInfo.php
+++ b/src/Queue/CreateInfo.php
@@ -78,7 +78,7 @@ class CreateInfo implements CreateInfoInterface
     public function toArray(): array
     {
         return [
-            'queue' => $this->name,
+            'name' => $this->name,
             'driver' => $this->driver,
             'priority' => $this->priority,
         ];

--- a/src/Queue/CreateInfoInterface.php
+++ b/src/Queue/CreateInfoInterface.php
@@ -18,7 +18,7 @@ namespace Spiral\RoadRunner\Jobs\Queue;
  * @psalm-import-type DriverType from Driver
  *
  * @psalm-type CreateInfoArrayType = array {
- *  queue: non-empty-string,
+ *  name: non-empty-string,
  *  driver: DriverType,
  *  priority: positive-int
  * }


### PR DESCRIPTION
The `queue` key is wrong. It should be `name`.
https://github.com/spiral/roadrunner-plugins/blob/b483288b98b0bbae0b2f2d41aa7db00f2d727207/jobs/pipeline/pipeline.go#L14