### PR TITLE
chore: change ramsey/uuid dependency version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
         "php": ">=7.4",
         "ext-json": "*",
         "opis/closure": "^3.6",
-        "ramsey/uuid": "^4.1",
+        "ramsey/uuid": "^3 || ^4",
         "spiral/roadrunner-worker": "^2.0",
         "spiral/roadrunner": "^2.0",
         "spiral/goridge": "^3.1",


### PR DESCRIPTION
Hello,

I think the requirement for `ramsey/uuid` could be a bit more open and allow older projects to enjoy your work :)

https://uuid.ramsey.dev/en/stable/upgrading/3-to-4.html