### PR TITLE
dont send the empty headers to RR

### DIFF
--- a/src/Task/ReceivedTask.php
+++ b/src/Task/ReceivedTask.php
@@ -109,12 +109,17 @@ final class ReceivedTask extends QueuedTask implements ReceivedTaskInterface
             'Precondition [error is string|Stringable|Throwable] failed'
         );
 
-        $this->respond(Type::ERROR, [
+        $data = [
             'message'       => (string)$error,
             'requeue'       => $requeue,
             'delay_seconds' => $this->delay,
-            'headers'       => $this->headers,
-        ]);
+        ];
+
+        if (!empty($this->headers)) {
+            $data['headers'] = $this->headers;
+        }
+
+        $this->respond(Type::ERROR, $data);
     }
 
     /**


### PR DESCRIPTION
RR dosent support `json` like for headers '[]'. We have two options:
1. add default headers
2. dont send `headers` key - was implemented