### PR TITLE
RR jobs plugin requires string map

### DIFF
--- a/src/Task/WritableHeadersTrait.php
+++ b/src/Task/WritableHeadersTrait.php
@@ -39,7 +39,7 @@ trait WritableHeadersTrait
         $self->headers[$name] = [];
 
         foreach ($value as $item) {
-            $self->headers[$name][] = $item;
+            $self->headers[$name][] = (string)$item;
         }
 
         return $self;


### PR DESCRIPTION
This solves an issue when you pass `->withHeader('header_name', 1)` and it breaks RR jobs plugin.