### PR TITLE
Fixes default task priority in a queue.

### DIFF
--- a/src/OptionsInterface.php
+++ b/src/OptionsInterface.php
@@ -21,7 +21,7 @@ interface OptionsInterface
     /**
      * @var positive-int|0
      */
-    public const DEFAULT_PRIORITY = 10;
+    public const DEFAULT_PRIORITY = 0;
 
     /**
      * @var bool


### PR DESCRIPTION
At the moment a queue sets priority for every pushed task to `10` and there is a problem with it.  If the priority value for these tasks was explicitly set, default priority from RoadRunner config can not be used.
If the priority value is `0`, then will be used a default value from RoadRunner config.