### PR TITLE
Mark Jobs::isAvailable method as deprecated.

### DIFF
--- a/src/Jobs.php
+++ b/src/Jobs.php
@@ -134,27 +134,6 @@ final class Jobs implements JobsInterface, SerializerAwareInterface
     /**
      * {@inheritDoc}
      */
-    public function isAvailable(): bool
-    {
-        try {
-            /** @var array<string>|mixed $result */
-            $result = $this->rpc
-                ->withCodec(new JsonCodec())
-                ->call('informer.List', true);
-
-            if (!\is_array($result)) {
-                return false;
-            }
-
-            return \in_array('jobs', $result, true);
-        } catch (\Throwable $e) {
-            return false;
-        }
-    }
-
-    /**
-     * {@inheritDoc}
-     */
     public function pause($queue, ...$queues): void
     {
         try {
@@ -241,5 +220,13 @@ final class Jobs implements JobsInterface, SerializerAwareInterface
         }
 
         return $names;
+    }
+
+    /**
+     * @deprecated Information about RoadRunner plugins is not available since RoadRunner version 2.2
+     */
+    public function isAvailable(): bool
+    {
+        throw new \RuntimeException(\sprintf('%s::isAvailable method is deprecated.', self::class));
     }
 }

--- a/src/JobsInterface.php
+++ b/src/JobsInterface.php
@@ -22,13 +22,6 @@ use Spiral\RoadRunner\Jobs\Queue\CreateInfoInterface;
 interface JobsInterface extends \IteratorAggregate, \Countable
 {
     /**
-     * The method returns information about the availability of the queue server.
-     *
-     * @return bool
-     */
-    public function isAvailable(): bool;
-
-    /**
      * A method that returns the selected queue. As the first argument, you
      * need to pass the name of a specific queue.
      *

--- a/tests/Unit/JobsTest.php
+++ b/tests/Unit/JobsTest.php
@@ -51,48 +51,6 @@ class JobsTestCase extends TestCase
     }
 
     /**
-     * @testdox The "jobs" should be available when checking the list of plugins.
-     */
-    public function testIsAvailable(): void
-    {
-        $jobs = $this->jobs(['informer.List' => '["jobs"]']);
-
-        $this->assertTrue($jobs->isAvailable());
-    }
-
-    /**
-     * @testdox If the list does not return "jobs", then "isAvailable()" should return false.
-     */
-    public function testNotAvailable(): void
-    {
-        $jobs = $this->jobs(['informer.List' => '[]']);
-
-        $this->assertFalse($jobs->isAvailable());
-    }
-
-    /**
-     * @testdox When checking jobs existence, incorrect server responses are processed correctly.
-     */
-    public function testNotAvailableOnNonArrayResponse(): void
-    {
-        $jobs = $this->jobs(['informer.List' => '42']);
-
-        $this->assertFalse($jobs->isAvailable());
-    }
-
-    /**
-     * @testdox In the case that the RR returned an error, this is processed correctly and the false is returned.
-     */
-    public function testNotAvailableOnErrorResponse(): void
-    {
-        $jobs = $this->jobs(['informer.List' => (static function () {
-            throw new \Exception();
-        })]);
-
-        $this->assertFalse($jobs->isAvailable());
-    }
-
-    /**
      * @testdox Checking the interaction with the RPC by the method of obtaining a list of queues.
      */
     public function testQueueListValues(): void

--- a/tests/Unit/JobsTest.php
+++ b/tests/Unit/JobsTest.php
@@ -30,6 +30,14 @@ class JobsTestCase extends TestCase
         return new Jobs($this->rpc($mapping));
     }
 
+    public function testIsAvailable(): void
+    {
+        $this->expectException(\RuntimeException::class);
+        $this->expectErrorMessage('Spiral\RoadRunner\Jobs\Jobs::isAvailable method is deprecated.');
+
+        $this->jobs()->isAvailable();
+    }
+
     /**
      * @testdox Checking creating a new queue with given info.
      */


### PR DESCRIPTION
Since RoadRunner version 2.3 there is not an ability to get list of available plugins via RPC and every time when developers started using this package they bumped into a problem with `Jobs::isAvailable` method. With this PR the method was marked as a deprecated and now it will throw an exception with information about deprecation.