### PR TITLE
fix: avoid exception when consuming an empty message sent into a Kafka topic

### DIFF
--- a/src/Consumer.php
+++ b/src/Consumer.php
@@ -121,7 +121,11 @@ final class Consumer implements ConsumerInterface, SerializerAwareInterface
      */
     private function getPayload(Payload $payload): array
     {
-        return $this->serializer->deserialize($payload->body);
+        if ($payload->body) {
+            return $this->serializer->deserialize($payload->body);
+        }
+
+        return [];
     }
 
     /**


### PR DESCRIPTION
Hi,

This PR avoids an exception when a message sent into a kafka topic has an empty body.
I also tested a message with an empty key (but with a valid body) and it works fine.

See: https://github.com/roadrunner-server/roadrunner/issues/1311

Thank you

closes: https://github.com/roadrunner-server/roadrunner/issues/1311