### PR TITLE
Adding headers to Options

### DIFF
--- a/src/Options.php
+++ b/src/Options.php
@@ -11,6 +11,7 @@ declare(strict_types=1);
 
 namespace Spiral\RoadRunner\Jobs;
 
+use Spiral\RoadRunner\Jobs\Task\ProvidesHeadersInterface;
 use Spiral\RoadRunner\Jobs\Task\WritableHeadersInterface;
 use Spiral\RoadRunner\Jobs\Task\WritableHeadersTrait;
 
@@ -167,6 +168,10 @@ class Options implements OptionsInterface, WritableHeadersInterface
 
         if (($autoAck = $options->getAutoAck()) !== self::DEFAULT_AUTO_ACK) {
             $self->autoAck = $autoAck;
+        }
+
+        if ($options instanceof ProvidesHeadersInterface && ($headers = $options->getHeaders()) !== []) {
+            $self->headers = $headers;
         }
 
         return $self;

--- a/src/Options.php
+++ b/src/Options.php
@@ -11,8 +11,13 @@ declare(strict_types=1);
 
 namespace Spiral\RoadRunner\Jobs;
 
-class Options implements OptionsInterface
+use Spiral\RoadRunner\Jobs\Task\WritableHeadersInterface;
+use Spiral\RoadRunner\Jobs\Task\WritableHeadersTrait;
+
+class Options implements OptionsInterface, WritableHeadersInterface
 {
+    use WritableHeadersTrait;
+
     /**
      * @var positive-int|0
      */

--- a/src/Queue.php
+++ b/src/Queue.php
@@ -25,6 +25,7 @@ use Spiral\RoadRunner\Jobs\Serializer\SerializerAwareInterface;
 use Spiral\RoadRunner\Jobs\Serializer\SerializerInterface;
 use Spiral\RoadRunner\Jobs\Task\PreparedTask;
 use Spiral\RoadRunner\Jobs\Task\PreparedTaskInterface;
+use Spiral\RoadRunner\Jobs\Task\ProvidesHeadersInterface;
 use Spiral\RoadRunner\Jobs\Task\QueuedTaskInterface;
 
 final class Queue implements QueueInterface, SerializerAwareInterface
@@ -136,7 +137,12 @@ final class Queue implements QueueInterface, SerializerAwareInterface
             $options = $this->options->mergeOptional($options);
         }
 
-        return new PreparedTask($name, $payload, $options);
+        return new PreparedTask(
+            $name,
+            $payload,
+            $options,
+            $options instanceof ProvidesHeadersInterface ? $options->getHeaders() : []
+        );
     }
 
     /**

--- a/src/Task/PreparedTask.php
+++ b/src/Task/PreparedTask.php
@@ -31,16 +31,13 @@ final class PreparedTask extends Task implements PreparedTaskInterface, OptionsA
      * @param non-empty-string $name
      * @param array $payload
      * @param OptionsInterface|null $options
+     * @param array<non-empty-string, array<string>> $headers
      */
-    public function __construct(string $name, array $payload, OptionsInterface $options = null)
+    public function __construct(string $name, array $payload, OptionsInterface $options = null, array $headers = [])
     {
         $this->options = $options ?? new Options();
 
-        parent::__construct(
-            $name,
-            $payload,
-            $options instanceof ProvidesHeadersInterface ? $options->getHeaders() : []
-        );
+        parent::__construct($name, $payload, $headers);
     }
 
     /**

--- a/src/Task/PreparedTask.php
+++ b/src/Task/PreparedTask.php
@@ -36,7 +36,11 @@ final class PreparedTask extends Task implements PreparedTaskInterface, OptionsA
     {
         $this->options = $options ?? new Options();
 
-        parent::__construct($name, $payload);
+        parent::__construct(
+            $name,
+            $payload,
+            $options instanceof ProvidesHeadersInterface ? $options->getHeaders() : []
+        );
     }
 
     /**

--- a/tests/Unit/QueueTest.php
+++ b/tests/Unit/QueueTest.php
@@ -14,6 +14,7 @@ namespace Spiral\RoadRunner\Jobs\Tests\Unit;
 use Spiral\RoadRunner\Jobs\DTO\V1\PushBatchRequest;
 use Spiral\RoadRunner\Jobs\DTO\V1\PushRequest;
 use Spiral\RoadRunner\Jobs\Exception\JobsException;
+use Spiral\RoadRunner\Jobs\Options;
 use Spiral\RoadRunner\Jobs\Queue;
 
 class QueueTestCase extends TestCase
@@ -129,5 +130,22 @@ class QueueTestCase extends TestCase
 
         $queue = $this->queue();
         $queue->resume();
+    }
+
+    public function testCreateWithHeaders(): void
+    {
+        $queue = $this->queue();
+
+        $this->assertSame(
+            ['foo' => ['bar']],
+            $queue->create('foo', [], (new Options())->withHeader('foo', 'bar'))->getHeaders()
+        );
+    }
+
+    public function testCreateWithoutHeaders(): void
+    {
+        $queue = $this->queue();
+
+        $this->assertSame([], $queue->create('foo')->getHeaders());
     }
 }

--- a/tests/Unit/Task/PreparedTaskTest.php
+++ b/tests/Unit/Task/PreparedTaskTest.php
@@ -28,6 +28,20 @@ final class PreparedTaskTest extends TestCase
         $this->assertSame('changed', $task->withOptions(new KafkaOptions('changed'))->getOptions()->getTopic());
     }
 
+    public function testCreatingTaskWithHeaders(): void
+    {
+        $task = new PreparedTask('foo', [], (new Options())->withHeader('foo', 'bar'));
+
+        $this->assertSame(['foo' => ['bar']], $task->getHeaders());
+    }
+
+    public function testCreatingTaskWithoutHeaders(): void
+    {
+        $task = new PreparedTask('foo', []);
+
+        $this->assertSame([], $task->getHeaders());
+    }
+
     public function optionsDataProvider(): \Traversable
     {
         yield [new Options(), null];

--- a/tests/Unit/Task/PreparedTaskTest.php
+++ b/tests/Unit/Task/PreparedTaskTest.php
@@ -30,7 +30,7 @@ final class PreparedTaskTest extends TestCase
 
     public function testCreatingTaskWithHeaders(): void
     {
-        $task = new PreparedTask('foo', [], (new Options())->withHeader('foo', 'bar'));
+        $task = new PreparedTask('foo', [], null, ['foo' => ['bar']]);
 
         $this->assertSame(['foo' => ['bar']], $task->getHeaders());
     }


### PR DESCRIPTION
Added headers to the `Options` and `PreparedTask`.

Parameter `array $headers = []` in the `PreparedTask` similar to the same parameter in the other tasks:
1) https://github.com/spiral/roadrunner-jobs/blob/master/src/Task/QueuedTask.php#L37
2) https://github.com/spiral/roadrunner-jobs/blob/master/src/Task/ReceivedTask.php#L27