### PR TITLE
Fixing tags and attributes in SQS

### DIFF
--- a/src/Queue/SQSCreateInfo.php
+++ b/src/Queue/SQSCreateInfo.php
@@ -137,13 +137,19 @@ final class SQSCreateInfo extends CreateInfo
      */
     public function toArray(): array
     {
-        return \array_merge(parent::toArray(), [
+        $result = \array_merge(parent::toArray(), [
             'prefetch'           => $this->prefetch,
             'visibility_timeout' => $this->visibilityTimeout,
             'wait_time_seconds'  => $this->waitTimeSeconds,
             'queue'              => $this->queue,
-            'attributes'         => $this->attributes,
-            'tags'               => $this->tags,
         ]);
+        if ($this->attributes !== []) {
+            $result['attributes'] = $this->attributes;
+        }
+        if ($this->tags !== []) {
+            $result['tags'] = $this->tags;
+        }
+
+        return $result;
     }
 }

--- a/tests/Unit/Queue/SQSCreateInfoTest.php
+++ b/tests/Unit/Queue/SQSCreateInfoTest.php
@@ -1,0 +1,75 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Spiral\RoadRunner\Jobs\Tests\Unit\Queue;
+
+use PHPUnit\Framework\TestCase;
+use Spiral\RoadRunner\Jobs\Queue\SQSCreateInfo;
+
+final class SQSCreateInfoTest extends TestCase
+{
+    public function testCreateWithTags(): void
+    {
+        $info = new SQSCreateInfo('foo', tags: ['foo' => 'bar']);
+
+        $this->assertSame([
+            'name' => 'foo',
+            'driver' => 'sqs',
+            'priority' => 10,
+            'prefetch' => 10,
+            'visibility_timeout' => 0,
+            'wait_time_seconds' => 0,
+            'queue' => 'default',
+            'tags' => ['foo' => 'bar']
+        ], $info->toArray());
+    }
+
+    public function testCreateWithAttributes(): void
+    {
+        $info = new SQSCreateInfo('foo', attributes: ['foo' => 'bar']);
+
+        $this->assertSame([
+            'name' => 'foo',
+            'driver' => 'sqs',
+            'priority' => 10,
+            'prefetch' => 10,
+            'visibility_timeout' => 0,
+            'wait_time_seconds' => 0,
+            'queue' => 'default',
+            'attributes' => ['foo' => 'bar']
+        ], $info->toArray());
+    }
+
+    public function testCreateWithTagsAndAttributes(): void
+    {
+        $info = new SQSCreateInfo('foo', attributes: ['foo' => 'bar'], tags: ['baz' => 'some']);
+
+        $this->assertSame([
+            'name' => 'foo',
+            'driver' => 'sqs',
+            'priority' => 10,
+            'prefetch' => 10,
+            'visibility_timeout' => 0,
+            'wait_time_seconds' => 0,
+            'queue' => 'default',
+            'attributes' => ['foo' => 'bar'],
+            'tags' => ['baz' => 'some']
+        ], $info->toArray());
+    }
+
+    public function testCreateWithoutTagsAndAttributes(): void
+    {
+        $info = new SQSCreateInfo('foo');
+
+        $this->assertSame([
+            'name' => 'foo',
+            'driver' => 'sqs',
+            'priority' => 10,
+            'prefetch' => 10,
+            'visibility_timeout' => 0,
+            'wait_time_seconds' => 0,
+            'queue' => 'default'
+        ], $info->toArray());
+    }
+}

--- a/tests/Unit/Queue/SQSCreateInfoTest.php
+++ b/tests/Unit/Queue/SQSCreateInfoTest.php
@@ -11,7 +11,16 @@ final class SQSCreateInfoTest extends TestCase
 {
     public function testCreateWithTags(): void
     {
-        $info = new SQSCreateInfo('foo', tags: ['foo' => 'bar']);
+        $info = new SQSCreateInfo(
+            'foo',
+            SQSCreateInfo::PRIORITY_DEFAULT_VALUE,
+            SQSCreateInfo::PREFETCH_DEFAULT_VALUE,
+            SQSCreateInfo::VISIBILITY_TIMEOUT_DEFAULT_VALUE,
+            SQSCreateInfo::WAIT_TIME_SECONDS_DEFAULT_VALUE,
+            SQSCreateInfo::QUEUE_DEFAULT_VALUE,
+            SQSCreateInfo::ATTRIBUTES_DEFAULT_VALUE,
+            ['foo' => 'bar']
+        );
 
         $this->assertSame([
             'name' => 'foo',
@@ -27,7 +36,15 @@ final class SQSCreateInfoTest extends TestCase
 
     public function testCreateWithAttributes(): void
     {
-        $info = new SQSCreateInfo('foo', attributes: ['foo' => 'bar']);
+        $info = new SQSCreateInfo(
+            'foo',
+            SQSCreateInfo::PRIORITY_DEFAULT_VALUE,
+            SQSCreateInfo::PREFETCH_DEFAULT_VALUE,
+            SQSCreateInfo::VISIBILITY_TIMEOUT_DEFAULT_VALUE,
+            SQSCreateInfo::WAIT_TIME_SECONDS_DEFAULT_VALUE,
+            SQSCreateInfo::QUEUE_DEFAULT_VALUE,
+            ['foo' => 'bar']
+        );
 
         $this->assertSame([
             'name' => 'foo',
@@ -43,7 +60,16 @@ final class SQSCreateInfoTest extends TestCase
 
     public function testCreateWithTagsAndAttributes(): void
     {
-        $info = new SQSCreateInfo('foo', attributes: ['foo' => 'bar'], tags: ['baz' => 'some']);
+        $info = new SQSCreateInfo(
+            'foo',
+            SQSCreateInfo::PRIORITY_DEFAULT_VALUE,
+            SQSCreateInfo::PREFETCH_DEFAULT_VALUE,
+            SQSCreateInfo::VISIBILITY_TIMEOUT_DEFAULT_VALUE,
+            SQSCreateInfo::WAIT_TIME_SECONDS_DEFAULT_VALUE,
+            SQSCreateInfo::QUEUE_DEFAULT_VALUE,
+            ['foo' => 'bar'],
+            ['baz' => 'some']
+        );
 
         $this->assertSame([
             'name' => 'foo',


### PR DESCRIPTION
If empty `tags` and `attributes` arrays are passed, RoadRunner returns an error:
```json: cannot unmarshal array into Go value of type map[string]string```