### PR TITLE
feat(AMQP): Add Header constants for consistent AMQP header usage

### DIFF
--- a/src/Queue/AMQP/Header.php
+++ b/src/Queue/AMQP/Header.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Spiral\RoadRunner\Jobs\Queue\AMQP;
+
+interface Header
+{
+    public const ROUTING_KEY = 'x-routing-key';
+}


### PR DESCRIPTION
We're excited to introduce a new utility class for users of the AMQP driver! With the primary goal of improving readability and ensuring consistent usage of AMQP headers, we've added a dedicated class to provide a list of available header constants.

💡 Usage Example
The new header can be used to set the `ROUTING KEY` header as shown:

```php
use Spiral\RoadRunner\Jobs\Queue\AMQP\Header;

/** @var QueueInterface $queue */
$queue->push(
    JobPayload::class,
    $payload,
    (new Options())
        ->onQueue('my_amqp_pipeline')
        ->withHeader(Header::ROUTING_KEY, '...') 
        ->withDelay(20)
);
```
https://github.com/roadrunner-server/roadrunner/issues/1555
https://github.com/roadrunner-php/issues/issues/7