### PR TITLE
Feature: AMQP queue headers

### DIFF
--- a/src/Queue/AMQPCreateInfo.php
+++ b/src/Queue/AMQPCreateInfo.php
@@ -18,6 +18,7 @@ final class AMQPCreateInfo extends CreateInfo
     public const REQUEUE_ON_FAIL_DEFAULT_VALUE = false;
     public const DURABLE_DEFAULT_VALUE = false;
     public const CONSUME_ALL_DEFAULT_VALUE = false;
+    public const QUEUE_HEADERS_DEFAULT_VALUE = [];
 
     /**
      * @param non-empty-string $name
@@ -26,6 +27,7 @@ final class AMQPCreateInfo extends CreateInfo
      * @param string $queue Queue name. Required for consumer.
      * @param non-empty-string $exchange
      * @param string $routingKey Routing key. Required for publisher.
+     * @param array<string, string> $queueHeaders
      */
     public function __construct(
         string $name,
@@ -41,6 +43,7 @@ final class AMQPCreateInfo extends CreateInfo
         public readonly bool $durable = self::DURABLE_DEFAULT_VALUE,
         public readonly bool $exchangeDurable = self::EXCHANGE_DURABLE_DEFAULT_VALUE,
         public readonly bool $consumeAll = self::CONSUME_ALL_DEFAULT_VALUE,
+        public readonly array $queueHeaders = self::QUEUE_HEADERS_DEFAULT_VALUE,
     ) {
         parent::__construct(Driver::AMQP, $name, $priority);
 
@@ -62,6 +65,7 @@ final class AMQPCreateInfo extends CreateInfo
             'requeue_on_fail' => $this->requeueOnFail,
             'durable' => $this->durable,
             'consume_all' => $this->consumeAll,
+            'queue_headers' => $this->queueHeaders,
         ]);
     }
 }

--- a/tests/Unit/Queue/AMQPCreateInfoTest.php
+++ b/tests/Unit/Queue/AMQPCreateInfoTest.php
@@ -38,7 +38,12 @@ final class AMQPCreateInfoTest extends TestCase
             true,
             true,
             true,
-            true
+            true,
+            true,
+            true,
+            [
+                'x-queue-type' => 'quorum',
+            ],
         );
 
         $this->assertSame(200, $amqpCreateInfo->prefetch);
@@ -50,6 +55,9 @@ final class AMQPCreateInfoTest extends TestCase
         $this->assertTrue($amqpCreateInfo->multipleAck);
         $this->assertTrue($amqpCreateInfo->requeueOnFail);
         $this->assertTrue($amqpCreateInfo->durable);
+        $this->assertTrue($amqpCreateInfo->exchangeDurable);
+        $this->assertTrue($amqpCreateInfo->consumeAll);
+        $this->assertSame(['x-queue-type' => 'quorum'], $amqpCreateInfo->queueHeaders);
     }
 
     public function testToArray()
@@ -65,7 +73,12 @@ final class AMQPCreateInfoTest extends TestCase
             true,
             true,
             true,
-            true
+            true,
+            true,
+            true,
+            [
+                'x-queue-type' => 'quorum',
+            ],
         );
 
         $expectedArray = [
@@ -81,8 +94,11 @@ final class AMQPCreateInfoTest extends TestCase
             'multiple_ack' => true,
             'requeue_on_fail' => true,
             'durable' => true,
-            'exchange_durable' => false,
-            'consume_all' => false,
+            'exchange_durable' => true,
+            'consume_all' => true,
+            'queue_headers' => [
+                'x-queue-type' => 'quorum',
+            ],
         ];
 
         $this->assertEquals($expectedArray, $amqpCreateInfo->toArray());


### PR DESCRIPTION
Feature: roadrunner-php/issues#22

Declare AMQP Queue headers

```php
// ...
'connector' => new AMQPCreateInfo(
    // ...
    queueHeaders: [
        'x-queue-type' => 'quorum',
        'x-dead-letter-exchange' => 'jobs-dlx',
    ],
),
// ...
```
