### PR TITLE
Add additional options when creating a pipeline

### DIFF
--- a/src/Queue/AMQPCreateInfo.php
+++ b/src/Queue/AMQPCreateInfo.php
@@ -10,6 +10,7 @@ final class AMQPCreateInfo extends CreateInfo
 {
     public const PREFETCH_DEFAULT_VALUE = 100;
     public const QUEUE_DEFAULT_VALUE = 'default';
+    public const QUEUE_AUTO_DELETE_DEFAULT_VALUE = false;
     public const EXCHANGE_DEFAULT_VALUE = 'amqp.default';
     public const EXCHANGE_DURABLE_DEFAULT_VALUE = false;
     public const ROUTING_KEY_DEFAULT_VALUE = '';
@@ -19,6 +20,10 @@ final class AMQPCreateInfo extends CreateInfo
     public const DURABLE_DEFAULT_VALUE = false;
     public const CONSUME_ALL_DEFAULT_VALUE = false;
     public const QUEUE_HEADERS_DEFAULT_VALUE = [];
+    public const DELETE_QUEUE_ON_STOP_DEFAULT_VALUE = false;
+    public const REDIAL_TIMEOUT_DEFAULT_VALUE = 60;
+    public const EXCHANGE_AUTO_DELETE_DEFAULT_VALUE = false;
+    public const CONSUMER_ID_DEFAULT_VALUE = null;
 
     /**
      * @param non-empty-string $name
@@ -28,6 +33,8 @@ final class AMQPCreateInfo extends CreateInfo
      * @param non-empty-string $exchange
      * @param string $routingKey Routing key. Required for publisher.
      * @param array<string, string> $queueHeaders
+     * @param positive-int $redialTimeout
+     * @param non-empty-string|null $consumerId
      */
     public function __construct(
         string $name,
@@ -44,21 +51,33 @@ final class AMQPCreateInfo extends CreateInfo
         public readonly bool $exchangeDurable = self::EXCHANGE_DURABLE_DEFAULT_VALUE,
         public readonly bool $consumeAll = self::CONSUME_ALL_DEFAULT_VALUE,
         public readonly array $queueHeaders = self::QUEUE_HEADERS_DEFAULT_VALUE,
+        public readonly bool $deleteQueueOnStop = self::DELETE_QUEUE_ON_STOP_DEFAULT_VALUE,
+        public readonly int $redialTimeout = self::REDIAL_TIMEOUT_DEFAULT_VALUE,
+        public readonly bool $exchangeAutoDelete = self::EXCHANGE_AUTO_DELETE_DEFAULT_VALUE,
+        public readonly bool $queueAutoDelete = self::QUEUE_AUTO_DELETE_DEFAULT_VALUE,
+        public readonly ?string $consumerId = self::CONSUMER_ID_DEFAULT_VALUE,
     ) {
         parent::__construct(Driver::AMQP, $name, $priority);
 
         \assert($this->prefetch >= 1, 'Precondition [prefetch >= 1] failed');
+        \assert($this->redialTimeout >= 1, 'Precondition [redialTimeout >= 1] failed');
         \assert($this->exchange !== '', 'Precondition [exchange !== ""] failed');
+
+        if ($this->consumerId !== null) {
+            \assert($this->consumerId !== '', 'Precondition [consumerId !== ""] failed');
+        }
     }
 
     public function toArray(): array
     {
-        return \array_merge(parent::toArray(), [
+        $result = \array_merge(parent::toArray(), [
             'prefetch' => $this->prefetch,
             'queue' => $this->queue,
+            'queue_auto_delete' => $this->queueAutoDelete,
             'exchange' => $this->exchange,
             'exchange_durable' => $this->exchangeDurable,
             'exchange_type' => $this->exchangeType->value,
+            'exchange_auto_delete' => $this->exchangeAutoDelete,
             'routing_key' => $this->routingKey,
             'exclusive' => $this->exclusive,
             'multiple_ack' => $this->multipleAck,
@@ -66,6 +85,14 @@ final class AMQPCreateInfo extends CreateInfo
             'durable' => $this->durable,
             'consume_all' => $this->consumeAll,
             'queue_headers' => $this->queueHeaders,
+            'delete_queue_on_stop' => $this->deleteQueueOnStop,
+            'redial_timeout' => $this->redialTimeout,
         ]);
+
+        if (!empty($this->consumerId)) {
+            $result['consumer_id'] = $this->consumerId;
+        }
+
+        return $result;
     }
 }

--- a/src/Queue/BeanstalkCreateInfo.php
+++ b/src/Queue/BeanstalkCreateInfo.php
@@ -13,6 +13,7 @@ final class BeanstalkCreateInfo extends CreateInfo
     public const TUBE_PRIORITY_MAX_VALUE = 2 ** 32;
     public const TUBE_DEFAULT_VALUE = 'default';
     public const RESERVE_TIMEOUT_DEFAULT_VALUE = 5;
+    public const CONSUME_ALL_DEFAULT_VALUE = false;
 
     /**
      * @param non-empty-string $name
@@ -27,6 +28,7 @@ final class BeanstalkCreateInfo extends CreateInfo
         public readonly int $tubePriority = self::TUBE_PRIORITY_DEFAULT_VALUE,
         public readonly string $tube = self::TUBE_DEFAULT_VALUE,
         public readonly int $reserveTimeout = self::RESERVE_TIMEOUT_DEFAULT_VALUE,
+        public readonly bool $consumeAll = self::CONSUME_ALL_DEFAULT_VALUE,
     ) {
         parent::__construct(Driver::Beanstalk, $name, $priority);
 
@@ -41,6 +43,7 @@ final class BeanstalkCreateInfo extends CreateInfo
             'tube_priority' => $this->tubePriority,
             'tube' => $this->tube,
             'reserve_timeout' => $this->reserveTimeout,
+            'consume_all' => $this->consumeAll,
         ]);
     }
 }

--- a/src/Queue/BoltdbCreateInfo.php
+++ b/src/Queue/BoltdbCreateInfo.php
@@ -11,6 +11,7 @@ final class BoltdbCreateInfo extends CreateInfo
 {
     public const PREFETCH_DEFAULT_VALUE = 10000;
     public const FILE_DEFAULT_VALUE = 'rr.db';
+    public const PERMISSIONS_DEFAULT_VALUE = 0777;
 
     /**
      * @param non-empty-string $name
@@ -23,6 +24,7 @@ final class BoltdbCreateInfo extends CreateInfo
         public readonly string $file = self::FILE_DEFAULT_VALUE,
         int $priority = self::PRIORITY_DEFAULT_VALUE,
         public readonly int $prefetch = self::PREFETCH_DEFAULT_VALUE,
+        public readonly int $permissions = self::PERMISSIONS_DEFAULT_VALUE,
     ) {
         parent::__construct(Driver::BoltDB, $name, $priority);
 
@@ -35,6 +37,7 @@ final class BoltdbCreateInfo extends CreateInfo
         return \array_merge(parent::toArray(), [
             'prefetch' => $this->prefetch,
             'file' => $this->file,
+            'permissions' => $this->permissions,
         ]);
     }
 }

--- a/src/Queue/BoltdbCreateInfo.php
+++ b/src/Queue/BoltdbCreateInfo.php
@@ -11,7 +11,7 @@ final class BoltdbCreateInfo extends CreateInfo
 {
     public const PREFETCH_DEFAULT_VALUE = 10000;
     public const FILE_DEFAULT_VALUE = 'rr.db';
-    public const PERMISSIONS_DEFAULT_VALUE = 0777;
+    public const PERMISSIONS_DEFAULT_VALUE = 0755;
 
     /**
      * @param non-empty-string $name

--- a/src/Queue/SQSCreateInfo.php
+++ b/src/Queue/SQSCreateInfo.php
@@ -33,6 +33,8 @@ final class SQSCreateInfo extends CreateInfo
     public const ATTRIBUTES_DEFAULT_VALUE = [];
     public const TAGS_DEFAULT_VALUE = [];
     public const QUEUE_DEFAULT_VALUE = 'default';
+    public const MESSAGE_GROUP_ID_DEFAULT_VALUE = null;
+    public const SKIP_QUEUE_DECLARATION_DEFAULT_VALUE = false;
 
     /**
      * @param non-empty-string $name
@@ -43,6 +45,7 @@ final class SQSCreateInfo extends CreateInfo
      * @param non-empty-string $queue
      * @param array|SQSAttributesMap $attributes
      * @param array<non-empty-string, non-empty-string> $tags
+     * @param non-empty-string|null $messageGroupId
      */
     public function __construct(
         string $name,
@@ -53,6 +56,8 @@ final class SQSCreateInfo extends CreateInfo
         public readonly string $queue = self::QUEUE_DEFAULT_VALUE,
         public readonly array $attributes = self::ATTRIBUTES_DEFAULT_VALUE,
         public readonly array $tags = self::TAGS_DEFAULT_VALUE,
+        public readonly ?string $messageGroupId = self::MESSAGE_GROUP_ID_DEFAULT_VALUE,
+        public readonly bool $skipQueueDeclaration = self::SKIP_QUEUE_DECLARATION_DEFAULT_VALUE,
     ) {
         parent::__construct(Driver::SQS, $name, $priority);
 
@@ -60,6 +65,9 @@ final class SQSCreateInfo extends CreateInfo
         \assert($this->visibilityTimeout >= 0, 'Precondition [visibilityTimeout >= 0] failed');
         \assert($this->waitTimeSeconds >= 0, 'Precondition [waitTimeSeconds >= 0] failed');
         \assert($this->queue !== '', 'Precondition [queue !== ""] failed');
+        if ($this->messageGroupId !== null) {
+            \assert($this->messageGroupId !== '', 'Precondition [messageGroupId !== ""] failed');
+        }
     }
 
     public function toArray(): array
@@ -67,14 +75,18 @@ final class SQSCreateInfo extends CreateInfo
         $result = \array_merge(parent::toArray(), [
             'prefetch' => $this->prefetch,
             'visibility_timeout' => $this->visibilityTimeout,
-            'wait_time_seconds' => $this->waitTimeSeconds,
+            'wait_time' => $this->waitTimeSeconds,
             'queue' => $this->queue,
+            'skip_queue_declaration' => $this->skipQueueDeclaration,
         ]);
         if ($this->attributes !== []) {
             $result['attributes'] = $this->attributes;
         }
         if ($this->tags !== []) {
             $result['tags'] = $this->tags;
+        }
+        if (!empty($this->messageGroupId)) {
+            $result['message_group_id'] = $this->messageGroupId;
         }
 
         return $result;

--- a/tests/Unit/Queue/AMQPCreateInfoTest.php
+++ b/tests/Unit/Queue/AMQPCreateInfoTest.php
@@ -14,6 +14,8 @@ final class AMQPCreateInfoTest extends TestCase
     {
         $amqpCreateInfo = new AMQPCreateInfo('test');
 
+        $this->assertSame('test', $amqpCreateInfo->name);
+        $this->assertSame(AMQPCreateInfo::PRIORITY_DEFAULT_VALUE, $amqpCreateInfo->priority);
         $this->assertSame(AMQPCreateInfo::PREFETCH_DEFAULT_VALUE, $amqpCreateInfo->prefetch);
         $this->assertSame(AMQPCreateInfo::QUEUE_DEFAULT_VALUE, $amqpCreateInfo->queue);
         $this->assertSame(AMQPCreateInfo::EXCHANGE_DEFAULT_VALUE, $amqpCreateInfo->exchange);
@@ -23,27 +25,40 @@ final class AMQPCreateInfoTest extends TestCase
         $this->assertFalse($amqpCreateInfo->multipleAck);
         $this->assertFalse($amqpCreateInfo->requeueOnFail);
         $this->assertFalse($amqpCreateInfo->durable);
+        $this->assertSame(AMQPCreateInfo::EXCHANGE_DURABLE_DEFAULT_VALUE, $amqpCreateInfo->exchangeDurable);
+        $this->assertSame(AMQPCreateInfo::CONSUME_ALL_DEFAULT_VALUE, $amqpCreateInfo->consumeAll);
+        $this->assertSame(AMQPCreateInfo::QUEUE_HEADERS_DEFAULT_VALUE, $amqpCreateInfo->queueHeaders);
+        $this->assertSame(AMQPCreateInfo::DELETE_QUEUE_ON_STOP_DEFAULT_VALUE, $amqpCreateInfo->deleteQueueOnStop);
+        $this->assertSame(AMQPCreateInfo::REDIAL_TIMEOUT_DEFAULT_VALUE, $amqpCreateInfo->redialTimeout);
+        $this->assertSame(AMQPCreateInfo::EXCHANGE_AUTO_DELETE_DEFAULT_VALUE, $amqpCreateInfo->exchangeAutoDelete);
+        $this->assertSame(AMQPCreateInfo::QUEUE_AUTO_DELETE_DEFAULT_VALUE, $amqpCreateInfo->queueAutoDelete);
+        $this->assertSame(AMQPCreateInfo::CONSUMER_ID_DEFAULT_VALUE, $amqpCreateInfo->consumerId);
     }
 
     public function testCustomValues(): void
     {
         $amqpCreateInfo = new AMQPCreateInfo(
-            'test',
-            5,
-            200,
-            'custom_queue',
-            'custom_exchange',
-            ExchangeType::Topics,
-            'custom_routing_key',
-            true,
-            true,
-            true,
-            true,
-            true,
-            true,
-            [
+            name: 'test',
+            priority: 5,
+            prefetch: 200,
+            queue: 'custom_queue',
+            exchange: 'custom_exchange',
+            exchangeType: ExchangeType::Topics,
+            routingKey: 'custom_routing_key',
+            exclusive: true,
+            multipleAck: true,
+            requeueOnFail: true,
+            durable: true,
+            exchangeDurable: true,
+            consumeAll: true,
+            queueHeaders: [
                 'x-queue-type' => 'quorum',
             ],
+            deleteQueueOnStop: true,
+            redialTimeout: 10,
+            exchangeAutoDelete: true,
+            queueAutoDelete: true,
+            consumerId: 'custom_consumer_id'
         );
 
         $this->assertSame(200, $amqpCreateInfo->prefetch);
@@ -58,27 +73,37 @@ final class AMQPCreateInfoTest extends TestCase
         $this->assertTrue($amqpCreateInfo->exchangeDurable);
         $this->assertTrue($amqpCreateInfo->consumeAll);
         $this->assertSame(['x-queue-type' => 'quorum'], $amqpCreateInfo->queueHeaders);
+        $this->assertTrue($amqpCreateInfo->deleteQueueOnStop);
+        $this->assertSame(10, $amqpCreateInfo->redialTimeout);
+        $this->assertTrue($amqpCreateInfo->exchangeAutoDelete);
+        $this->assertTrue($amqpCreateInfo->queueAutoDelete);
+        $this->assertSame('custom_consumer_id', $amqpCreateInfo->consumerId);
     }
 
-    public function testToArray()
+    public function testToArray(): void
     {
         $amqpCreateInfo = new AMQPCreateInfo(
-            'test',
-            5,
-            200,
-            'custom_queue',
-            'custom_exchange',
-            ExchangeType::Fanout,
-            'custom_routing_key',
-            true,
-            true,
-            true,
-            true,
-            true,
-            true,
-            [
+            name: 'test',
+            priority: 5,
+            prefetch: 200,
+            queue: 'custom_queue',
+            exchange: 'custom_exchange',
+            exchangeType: ExchangeType::Fanout,
+            routingKey: 'custom_routing_key',
+            exclusive: true,
+            multipleAck: true,
+            requeueOnFail: true,
+            durable: true,
+            exchangeDurable: true,
+            consumeAll: true,
+            queueHeaders: [
                 'x-queue-type' => 'quorum',
             ],
+            deleteQueueOnStop: true,
+            redialTimeout: 10,
+            exchangeAutoDelete: true,
+            queueAutoDelete: true,
+            consumerId: 'custom_consumer_id'
         );
 
         $expectedArray = [
@@ -99,6 +124,11 @@ final class AMQPCreateInfoTest extends TestCase
             'queue_headers' => [
                 'x-queue-type' => 'quorum',
             ],
+            'exchange_auto_delete' => true,
+            'delete_queue_on_stop' => true,
+            'redial_timeout' => 10,
+            'queue_auto_delete' => true,
+            'consumer_id' => 'custom_consumer_id'
         ];
 
         $this->assertEquals($expectedArray, $amqpCreateInfo->toArray());

--- a/tests/Unit/Queue/BeanstalkCreateInfoTest.php
+++ b/tests/Unit/Queue/BeanstalkCreateInfoTest.php
@@ -21,6 +21,7 @@ final class BeanstalkCreateInfoTest extends TestCase
         $this->assertEquals(BeanstalkCreateInfo::TUBE_PRIORITY_DEFAULT_VALUE, $beanstalkCreateInfo->tubePriority);
         $this->assertEquals(BeanstalkCreateInfo::TUBE_DEFAULT_VALUE, $beanstalkCreateInfo->tube);
         $this->assertEquals(BeanstalkCreateInfo::RESERVE_TIMEOUT_DEFAULT_VALUE, $beanstalkCreateInfo->reserveTimeout);
+        $this->assertEquals(BeanstalkCreateInfo::CONSUME_ALL_DEFAULT_VALUE, $beanstalkCreateInfo->consumeAll);
     }
 
     public function testBeanstalkCreateInfoCustomValues(): void
@@ -30,8 +31,16 @@ final class BeanstalkCreateInfoTest extends TestCase
         $tubePriority = 100;
         $tube = 'my-tube';
         $reserveTimeout = 30;
+        $consumeAll = true;
 
-        $beanstalkCreateInfo = new BeanstalkCreateInfo($name, $priority, $tubePriority, $tube, $reserveTimeout);
+        $beanstalkCreateInfo = new BeanstalkCreateInfo(
+            name: $name,
+            priority: $priority,
+            tubePriority: $tubePriority,
+            tube: $tube,
+            reserveTimeout: $reserveTimeout,
+            consumeAll: $consumeAll
+        );
 
         $this->assertEquals(Driver::Beanstalk, $beanstalkCreateInfo->driver);
         $this->assertEquals($name, $beanstalkCreateInfo->name);
@@ -39,6 +48,7 @@ final class BeanstalkCreateInfoTest extends TestCase
         $this->assertEquals($tubePriority, $beanstalkCreateInfo->tubePriority);
         $this->assertEquals($tube, $beanstalkCreateInfo->tube);
         $this->assertEquals($reserveTimeout, $beanstalkCreateInfo->reserveTimeout);
+        $this->assertEquals($consumeAll, $beanstalkCreateInfo->consumeAll);
     }
 
     public function testToArray(): void
@@ -48,8 +58,16 @@ final class BeanstalkCreateInfoTest extends TestCase
         $tubePriority = 100;
         $tube = 'my-tube';
         $reserveTimeout = 30;
+        $consumeAll = true;
 
-        $beanstalkCreateInfo = new BeanstalkCreateInfo($name, $priority, $tubePriority, $tube, $reserveTimeout);
+        $beanstalkCreateInfo = new BeanstalkCreateInfo(
+            name: $name,
+            priority: $priority,
+            tubePriority: $tubePriority,
+            tube: $tube,
+            reserveTimeout: $reserveTimeout,
+            consumeAll: $consumeAll
+        );
 
         $expectedArray = [
             'driver' => Driver::Beanstalk->value,
@@ -58,6 +76,7 @@ final class BeanstalkCreateInfoTest extends TestCase
             'tube_priority' => $tubePriority,
             'tube' => $tube,
             'reserve_timeout' => $reserveTimeout,
+            'consume_all' => $consumeAll,
         ];
 
         $this->assertEquals($expectedArray, $beanstalkCreateInfo->toArray());

--- a/tests/Unit/Queue/BoltdbCreateInfoTest.php
+++ b/tests/Unit/Queue/BoltdbCreateInfoTest.php
@@ -51,7 +51,7 @@ final class BoltdbCreateInfoTest extends TestCase
             'priority' => $priority,
             'prefetch' => $prefetch,
             'file' => $file,
-            'permissions' => 0777,
+            'permissions' => 0755,
         ];
 
         $this->assertEquals($expectedArray, $boltdbCreateInfo->toArray());

--- a/tests/Unit/Queue/BoltdbCreateInfoTest.php
+++ b/tests/Unit/Queue/BoltdbCreateInfoTest.php
@@ -15,13 +15,15 @@ final class BoltdbCreateInfoTest extends TestCase
         $file = 'custom_file.db';
         $priority = 2;
         $prefetch = 5000;
+        $permissions = 0666;
 
-        $boltdbCreateInfo = new BoltdbCreateInfo($name, $file, $priority, $prefetch);
+        $boltdbCreateInfo = new BoltdbCreateInfo($name, $file, $priority, $prefetch, $permissions);
 
         $this->assertEquals($name, $boltdbCreateInfo->name);
         $this->assertEquals($file, $boltdbCreateInfo->file);
         $this->assertEquals($priority, $boltdbCreateInfo->priority);
         $this->assertEquals($prefetch, $boltdbCreateInfo->prefetch);
+        $this->assertEquals($permissions, $boltdbCreateInfo->permissions);
     }
 
     public function testDefaultValues(): void
@@ -31,6 +33,7 @@ final class BoltdbCreateInfoTest extends TestCase
         $this->assertEquals(BoltdbCreateInfo::PRIORITY_DEFAULT_VALUE, $boltdbCreateInfo->priority);
         $this->assertEquals(BoltdbCreateInfo::PREFETCH_DEFAULT_VALUE, $boltdbCreateInfo->prefetch);
         $this->assertEquals(BoltdbCreateInfo::FILE_DEFAULT_VALUE, $boltdbCreateInfo->file);
+        $this->assertEquals(BoltdbCreateInfo::PERMISSIONS_DEFAULT_VALUE, $boltdbCreateInfo->permissions);
     }
 
     public function testToArray(): void
@@ -48,6 +51,7 @@ final class BoltdbCreateInfoTest extends TestCase
             'priority' => $priority,
             'prefetch' => $prefetch,
             'file' => $file,
+            'permissions' => 0777,
         ];
 
         $this->assertEquals($expectedArray, $boltdbCreateInfo->toArray());

--- a/tests/Unit/Queue/SQSCreateInfoTest.php
+++ b/tests/Unit/Queue/SQSCreateInfoTest.php
@@ -13,14 +13,16 @@ final class SQSCreateInfoTest extends TestCase
     public function testConstructor(): void
     {
         $sqsCreateInfo = new SQSCreateInfo(
-            'testName',
-            1,
-            20,
-            30,
-            40,
-            'customQueue',
-            ['key' => 'value'],
-            ['tagKey' => 'tagValue']
+            name: 'testName',
+            priority: 1,
+            prefetch: 20,
+            visibilityTimeout: 30,
+            waitTimeSeconds: 40,
+            queue: 'customQueue',
+            attributes: ['key' => 'value'],
+            tags: ['tagKey' => 'tagValue'],
+            messageGroupId: 'customMessageGroupId',
+            skipQueueDeclaration: true,
         );
 
         $this->assertEquals(Driver::SQS, $sqsCreateInfo->driver);
@@ -32,19 +34,21 @@ final class SQSCreateInfoTest extends TestCase
         $this->assertEquals('customQueue', $sqsCreateInfo->queue);
         $this->assertEquals(['key' => 'value'], $sqsCreateInfo->attributes);
         $this->assertEquals(['tagKey' => 'tagValue'], $sqsCreateInfo->tags);
+        $this->assertEquals('customMessageGroupId', $sqsCreateInfo->messageGroupId);
+        $this->assertTrue( $sqsCreateInfo->skipQueueDeclaration);
     }
 
     public function testToArray(): void
     {
         $sqsCreateInfo = new SQSCreateInfo(
-            'testName',
-            1,
-            20,
-            30,
-            40,
-            'customQueue',
-            ['key' => 'value'],
-            ['tagKey' => 'tagValue']
+            name: 'testName',
+            priority: 1,
+            prefetch: 20,
+            visibilityTimeout: 30,
+            waitTimeSeconds: 40,
+            queue: 'customQueue',
+            attributes: ['key' => 'value'],
+            tags: ['tagKey' => 'tagValue']
         );
 
         $result = $sqsCreateInfo->toArray();
@@ -54,10 +58,11 @@ final class SQSCreateInfoTest extends TestCase
             'priority' => 1,
             'prefetch' => 20,
             'visibility_timeout' => 30,
-            'wait_time_seconds' => 40,
+            'wait_time' => 40,
             'queue' => 'customQueue',
             'attributes' => ['key' => 'value'],
             'tags' => ['tagKey' => 'tagValue'],
+            'skip_queue_declaration' => false,
         ];
 
         $this->assertEquals($expected, $result);
@@ -77,15 +82,16 @@ final class SQSCreateInfoTest extends TestCase
             ['foo' => 'bar']
         );
 
-        $this->assertSame([
+        $this->assertEquals([
             'name' => 'foo',
             'driver' => 'sqs',
             'priority' => 10,
             'prefetch' => 10,
             'visibility_timeout' => 0,
-            'wait_time_seconds' => 0,
+            'wait_time' => 0,
             'queue' => 'default',
             'tags' => ['foo' => 'bar'],
+            'skip_queue_declaration' => false,
         ], $info->toArray());
     }
 
@@ -101,19 +107,20 @@ final class SQSCreateInfoTest extends TestCase
             ['foo' => 'bar']
         );
 
-        $this->assertSame([
+        $this->assertEquals([
             'name' => 'foo',
             'driver' => 'sqs',
             'priority' => 10,
             'prefetch' => 10,
             'visibility_timeout' => 0,
-            'wait_time_seconds' => 0,
+            'wait_time' => 0,
             'queue' => 'default',
             'attributes' => ['foo' => 'bar'],
+            'skip_queue_declaration' => false,
         ], $info->toArray());
     }
 
-    public function testToArrayWithDefaults()
+    public function testToArrayWithDefaults(): void
     {
         $sqsCreateInfo = new SQSCreateInfo('testName');
 
@@ -124,8 +131,9 @@ final class SQSCreateInfoTest extends TestCase
             'priority' => SQSCreateInfo::PRIORITY_DEFAULT_VALUE,
             'prefetch' => SQSCreateInfo::PREFETCH_DEFAULT_VALUE,
             'visibility_timeout' => SQSCreateInfo::VISIBILITY_TIMEOUT_DEFAULT_VALUE,
-            'wait_time_seconds' => SQSCreateInfo::WAIT_TIME_SECONDS_DEFAULT_VALUE,
+            'wait_time' => SQSCreateInfo::WAIT_TIME_SECONDS_DEFAULT_VALUE,
             'queue' => SQSCreateInfo::QUEUE_DEFAULT_VALUE,
+            'skip_queue_declaration' => false,
         ];
 
         $this->assertEquals($expected, $result);
@@ -144,16 +152,17 @@ final class SQSCreateInfoTest extends TestCase
             ['baz' => 'some']
         );
 
-        $this->assertSame([
+        $this->assertEquals([
             'name' => 'foo',
             'driver' => 'sqs',
             'priority' => 10,
             'prefetch' => 10,
             'visibility_timeout' => 0,
-            'wait_time_seconds' => 0,
+            'wait_time' => 0,
             'queue' => 'default',
             'attributes' => ['foo' => 'bar'],
             'tags' => ['baz' => 'some'],
+            'skip_queue_declaration' => false,
         ], $info->toArray());
     }
 
@@ -167,8 +176,26 @@ final class SQSCreateInfoTest extends TestCase
             'priority' => 10,
             'prefetch' => 10,
             'visibility_timeout' => 0,
-            'wait_time_seconds' => 0,
+            'wait_time' => 0,
             'queue' => 'default',
+            'skip_queue_declaration' => false,
+        ], $info->toArray());
+    }
+
+    public function testCreateWithMessageGroupId(): void
+    {
+        $info = new SQSCreateInfo(name: 'foo', messageGroupId: 'bar');
+
+        $this->assertSame([
+            'name' => 'foo',
+            'driver' => 'sqs',
+            'priority' => 10,
+            'prefetch' => 10,
+            'visibility_timeout' => 0,
+            'wait_time' => 0,
+            'queue' => 'default',
+            'skip_queue_declaration' => false,
+            'message_group_id' => 'bar',
         ], $info->toArray());
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bugfix?       | ❌
| Breaks BC?    | ❌
| New feature?  | ✔️
| Issues        | closes: https://github.com/roadrunner-php/issues/issues/26

This pull request adds additional options when creating a pipeline.

#### AMQP

- queue_auto_delete
- exchange_auto_delete
- delete_queue_on_stop
- redial_timeout
- consumer_id

These options are available in the driver configuration: https://github.com/roadrunner-server/amqp/blob/master/amqpjobs/config.go#L24 and in the configuration file `.rr.yaml`:
https://github.com/roadrunner-server/roadrunner/blob/master/.rr.yaml#L1402

#### Beanstalk

- consume_all

This option is available in the driver configuration: https://github.com/roadrunner-server/beanstalk/blob/master/beanstalkjobs/config.go#L11 and in the configuration file `.rr.yaml`:
https://github.com/roadrunner-server/roadrunner/blob/master/.rr.yaml#L1521

####  Boltdb

- permissions

This option is available in the driver configuration: https://github.com/roadrunner-server/boltdb/blob/master/boltjobs/config.go#L6 and in the configuration file `.rr.yaml`:
https://github.com/roadrunner-server/roadrunner/blob/master/.rr.yaml#L1391

#### SQS

- message_group_id
- skip_queue_declaration

Changed parameter from `wait_time_seconds` to `wait_time`. See: https://github.com/roadrunner-server/sqs/blob/master/sqsjobs/config.go#L16

These options are available in the driver configuration: https://github.com/roadrunner-server/sqs/blob/master/sqsjobs/config.go#L9 and in the configuration file `.rr.yaml`: https://github.com/roadrunner-server/roadrunner/blob/master/.rr.yaml#L1542



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced new configuration options for queue creation across various queue types (AMQP, Beanstalk, Boltdb, SQS), enhancing customization and control.
- **Tests**
	- Updated unit tests to validate new configuration options and their default values, ensuring robustness and reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->