### PR TITLE
Add support for ack, nack, and requeue methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,7 +137,7 @@ while ($task = $consumer->waitTask()) {
     try {
         $name = $task->getName(); // "ping"
         $queue = $task->getQueue(); // "local"
-        $driver = $queue->getDriver(); // "memory"
+        $driver = $task->getDriver(); // "memory"
         $payload = $task->getPayload(); // {"site": "https://example.com"}
     
         // Process task

--- a/psalm.xml
+++ b/psalm.xml
@@ -13,6 +13,7 @@
         <RedundantCastGivenDocblockType errorLevel="suppress" />
         <RedundantCondition errorLevel="suppress" />
         <DocblockTypeContradiction errorLevel="suppress" />
+        <MissingClassConstType errorLevel="suppress" />
     </issueHandlers>
     <projectFiles>
         <directory name="src" />

--- a/src/Task/ReceivedTask.php
+++ b/src/Task/ReceivedTask.php
@@ -93,6 +93,9 @@ class ReceivedTask extends QueuedTask implements ReceivedTaskInterface
         $this->respond(Type::ACK);
     }
 
+    /**
+     * The behavior of this method depends on its implementation by the queue driver.
+     */
     public function nack(string|\Stringable|\Throwable $message, bool $redelivery = false): void
     {
         $this->respond(Type::NACK, [

--- a/src/Task/ReceivedTask.php
+++ b/src/Task/ReceivedTask.php
@@ -67,6 +67,7 @@ class ReceivedTask extends QueuedTask implements ReceivedTaskInterface
      */
     public function complete(): void
     {
+        /** @psalm-suppress DeprecatedConstant */
         $this->respond(Type::SUCCESS);
     }
 
@@ -85,6 +86,7 @@ class ReceivedTask extends QueuedTask implements ReceivedTaskInterface
             $data['headers'] = $this->headers;
         }
 
+        /** @psalm-suppress DeprecatedConstant */
         $this->respond(Type::ERROR, $data);
     }
 
@@ -126,11 +128,13 @@ class ReceivedTask extends QueuedTask implements ReceivedTaskInterface
 
     public function isSuccessful(): bool
     {
+        /** @psalm-suppress DeprecatedConstant */
         return $this->completed === Type::SUCCESS || $this->completed === Type::ACK;
     }
 
     public function isFails(): bool
     {
+        /** @psalm-suppress DeprecatedConstant */
         return $this->completed === Type::ERROR ||
             $this->completed === Type::NACK ||
             $this->completed === Type::REQUEUE;

--- a/src/Task/ReceivedTaskInterface.php
+++ b/src/Task/ReceivedTaskInterface.php
@@ -9,6 +9,9 @@ use Spiral\RoadRunner\Jobs\Queue\Driver;
 
 /**
  * @psalm-suppress MissingImmutableAnnotation The implementation of this task is mutable.
+ * @method void ack()
+ * @method void nack(string|\Stringable|\Throwable $message, bool $redelivery = false)
+ * @method void requeue(string|\Stringable|\Throwable $message)
  */
 interface ReceivedTaskInterface extends
     QueuedTaskInterface,
@@ -19,6 +22,7 @@ interface ReceivedTaskInterface extends
      * Marks the current task as completed.
      *
      * @throws JobsException
+     * @deprecated Since v4.5.0, use {@see ack()} instead.
      */
     public function complete(): void;
 
@@ -26,6 +30,7 @@ interface ReceivedTaskInterface extends
      * Marks the current task as failed.
      *
      * @throws JobsException
+     * @deprecated Since v4.5.0, use {@see nack()} or {@see requeue()} instead.
      */
     public function fail(string|\Stringable|\Throwable $error, bool $requeue = false): void;
 

--- a/src/Task/Type.php
+++ b/src/Task/Type.php
@@ -11,11 +11,28 @@ interface Type
 {
     /**
      * @var TypeEnum
+     * @deprecated Since v4.5.0, use {@see Type::ACK} instead.
      */
     public const SUCCESS = 0;
 
     /**
      * @var TypeEnum
+     * @deprecated Since v4.5.0, use {@see Type::NACK} or {@see Type::REQUEUE} instead.
      */
     public const ERROR = 1;
+
+    /**
+     * @var TypeEnum
+     */
+    public const ACK = 2;
+
+    /**
+     * @var TypeEnum
+     */
+    public const NACK = 3;
+
+    /**
+     * @var TypeEnum
+     */
+    public const REQUEUE = 4;
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bugfix?       | ❌
| Breaks BC?    | ❌ 
| New feature?  | ✔️
| Issues        | https://github.com/roadrunner-server/roadrunner/issues/1941

Added support for `ack`, `nack`, and `requeue` methods.

Closes: https://github.com/roadrunner-server/roadrunner/issues/1941
