### PR TITLE
Adding support for google/protobuf v4.x

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -45,7 +45,6 @@
     "require": {
         "php": ">=8.1",
         "ext-json": "*",
-        "google/protobuf": "^v3.17",
         "ramsey/uuid": "^3 || ^4",
         "roadrunner-php/roadrunner-api-dto": "^1.0",
         "spiral/goridge": "^4.0",
@@ -53,6 +52,7 @@
         "spiral/roadrunner-worker": "^3.0"
     },
     "require-dev": {
+        "google/protobuf": "^3.17 || ^4.0",
         "phpunit/phpunit": "^10.0",
         "roave/security-advisories": "dev-master",
         "vimeo/psalm": ">=5.8"


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bugfix?       | ❌
| Breaks BC?    | ❌ 
| New feature?  | ✔️
| Issues        | #https://github.com/roadrunner-php/issues/issues/35

The `google/protobuf` dependency has been moved to **require-dev** because it is only used in tests.
