### PR TITLE
chore: Remove unused `consume_all` parameter

### DIFF
--- a/src/Queue/AMQPCreateInfo.php
+++ b/src/Queue/AMQPCreateInfo.php
@@ -18,7 +18,6 @@ final class AMQPCreateInfo extends CreateInfo
     public const MULTIPLE_ACK_DEFAULT_VALUE = false;
     public const REQUEUE_ON_FAIL_DEFAULT_VALUE = false;
     public const DURABLE_DEFAULT_VALUE = false;
-    public const CONSUME_ALL_DEFAULT_VALUE = false;
     public const QUEUE_HEADERS_DEFAULT_VALUE = [];
     public const DELETE_QUEUE_ON_STOP_DEFAULT_VALUE = false;
     public const REDIAL_TIMEOUT_DEFAULT_VALUE = 60;
@@ -49,7 +48,6 @@ final class AMQPCreateInfo extends CreateInfo
         public readonly bool $requeueOnFail = self::REQUEUE_ON_FAIL_DEFAULT_VALUE,
         public readonly bool $durable = self::DURABLE_DEFAULT_VALUE,
         public readonly bool $exchangeDurable = self::EXCHANGE_DURABLE_DEFAULT_VALUE,
-        public readonly bool $consumeAll = self::CONSUME_ALL_DEFAULT_VALUE,
         public readonly array $queueHeaders = self::QUEUE_HEADERS_DEFAULT_VALUE,
         public readonly bool $deleteQueueOnStop = self::DELETE_QUEUE_ON_STOP_DEFAULT_VALUE,
         public readonly int $redialTimeout = self::REDIAL_TIMEOUT_DEFAULT_VALUE,
@@ -83,7 +81,6 @@ final class AMQPCreateInfo extends CreateInfo
             'multiple_ack' => $this->multipleAck,
             'requeue_on_fail' => $this->requeueOnFail,
             'durable' => $this->durable,
-            'consume_all' => $this->consumeAll,
             'delete_queue_on_stop' => $this->deleteQueueOnStop,
             'redial_timeout' => $this->redialTimeout,
         ]);

--- a/src/Queue/BeanstalkCreateInfo.php
+++ b/src/Queue/BeanstalkCreateInfo.php
@@ -13,7 +13,6 @@ final class BeanstalkCreateInfo extends CreateInfo
     public const TUBE_PRIORITY_MAX_VALUE = 2 ** 32;
     public const TUBE_DEFAULT_VALUE = 'default';
     public const RESERVE_TIMEOUT_DEFAULT_VALUE = 5;
-    public const CONSUME_ALL_DEFAULT_VALUE = false;
 
     /**
      * @param non-empty-string $name
@@ -28,7 +27,6 @@ final class BeanstalkCreateInfo extends CreateInfo
         public readonly int $tubePriority = self::TUBE_PRIORITY_DEFAULT_VALUE,
         public readonly string $tube = self::TUBE_DEFAULT_VALUE,
         public readonly int $reserveTimeout = self::RESERVE_TIMEOUT_DEFAULT_VALUE,
-        public readonly bool $consumeAll = self::CONSUME_ALL_DEFAULT_VALUE,
     ) {
         parent::__construct(Driver::Beanstalk, $name, $priority);
 
@@ -43,7 +41,6 @@ final class BeanstalkCreateInfo extends CreateInfo
             'tube_priority' => $this->tubePriority,
             'tube' => $this->tube,
             'reserve_timeout' => $this->reserveTimeout,
-            'consume_all' => $this->consumeAll,
         ]);
     }
 }

--- a/tests/Unit/Queue/AMQPCreateInfoTest.php
+++ b/tests/Unit/Queue/AMQPCreateInfoTest.php
@@ -26,7 +26,6 @@ final class AMQPCreateInfoTest extends TestCase
         $this->assertFalse($amqpCreateInfo->requeueOnFail);
         $this->assertFalse($amqpCreateInfo->durable);
         $this->assertSame(AMQPCreateInfo::EXCHANGE_DURABLE_DEFAULT_VALUE, $amqpCreateInfo->exchangeDurable);
-        $this->assertSame(AMQPCreateInfo::CONSUME_ALL_DEFAULT_VALUE, $amqpCreateInfo->consumeAll);
         $this->assertSame(AMQPCreateInfo::QUEUE_HEADERS_DEFAULT_VALUE, $amqpCreateInfo->queueHeaders);
         $this->assertSame(AMQPCreateInfo::DELETE_QUEUE_ON_STOP_DEFAULT_VALUE, $amqpCreateInfo->deleteQueueOnStop);
         $this->assertSame(AMQPCreateInfo::REDIAL_TIMEOUT_DEFAULT_VALUE, $amqpCreateInfo->redialTimeout);
@@ -50,7 +49,6 @@ final class AMQPCreateInfoTest extends TestCase
             requeueOnFail: true,
             durable: true,
             exchangeDurable: true,
-            consumeAll: true,
             queueHeaders: [
                 'x-queue-type' => 'quorum',
             ],
@@ -71,7 +69,6 @@ final class AMQPCreateInfoTest extends TestCase
         $this->assertTrue($amqpCreateInfo->requeueOnFail);
         $this->assertTrue($amqpCreateInfo->durable);
         $this->assertTrue($amqpCreateInfo->exchangeDurable);
-        $this->assertTrue($amqpCreateInfo->consumeAll);
         $this->assertSame(['x-queue-type' => 'quorum'], $amqpCreateInfo->queueHeaders);
         $this->assertTrue($amqpCreateInfo->deleteQueueOnStop);
         $this->assertSame(10, $amqpCreateInfo->redialTimeout);
@@ -95,7 +92,6 @@ final class AMQPCreateInfoTest extends TestCase
             requeueOnFail: true,
             durable: true,
             exchangeDurable: true,
-            consumeAll: true,
             queueHeaders: [
                 'x-queue-type' => 'quorum',
             ],
@@ -120,7 +116,6 @@ final class AMQPCreateInfoTest extends TestCase
             'requeue_on_fail' => true,
             'durable' => true,
             'exchange_durable' => true,
-            'consume_all' => true,
             'queue_headers' => [
                 'x-queue-type' => 'quorum',
             ],

--- a/tests/Unit/Queue/BeanstalkCreateInfoTest.php
+++ b/tests/Unit/Queue/BeanstalkCreateInfoTest.php
@@ -21,7 +21,6 @@ final class BeanstalkCreateInfoTest extends TestCase
         $this->assertEquals(BeanstalkCreateInfo::TUBE_PRIORITY_DEFAULT_VALUE, $beanstalkCreateInfo->tubePriority);
         $this->assertEquals(BeanstalkCreateInfo::TUBE_DEFAULT_VALUE, $beanstalkCreateInfo->tube);
         $this->assertEquals(BeanstalkCreateInfo::RESERVE_TIMEOUT_DEFAULT_VALUE, $beanstalkCreateInfo->reserveTimeout);
-        $this->assertEquals(BeanstalkCreateInfo::CONSUME_ALL_DEFAULT_VALUE, $beanstalkCreateInfo->consumeAll);
     }
 
     public function testBeanstalkCreateInfoCustomValues(): void
@@ -31,15 +30,13 @@ final class BeanstalkCreateInfoTest extends TestCase
         $tubePriority = 100;
         $tube = 'my-tube';
         $reserveTimeout = 30;
-        $consumeAll = true;
 
         $beanstalkCreateInfo = new BeanstalkCreateInfo(
             name: $name,
             priority: $priority,
             tubePriority: $tubePriority,
             tube: $tube,
-            reserveTimeout: $reserveTimeout,
-            consumeAll: $consumeAll
+            reserveTimeout: $reserveTimeout
         );
 
         $this->assertEquals(Driver::Beanstalk, $beanstalkCreateInfo->driver);
@@ -48,7 +45,6 @@ final class BeanstalkCreateInfoTest extends TestCase
         $this->assertEquals($tubePriority, $beanstalkCreateInfo->tubePriority);
         $this->assertEquals($tube, $beanstalkCreateInfo->tube);
         $this->assertEquals($reserveTimeout, $beanstalkCreateInfo->reserveTimeout);
-        $this->assertEquals($consumeAll, $beanstalkCreateInfo->consumeAll);
     }
 
     public function testToArray(): void
@@ -58,15 +54,13 @@ final class BeanstalkCreateInfoTest extends TestCase
         $tubePriority = 100;
         $tube = 'my-tube';
         $reserveTimeout = 30;
-        $consumeAll = true;
 
         $beanstalkCreateInfo = new BeanstalkCreateInfo(
             name: $name,
             priority: $priority,
             tubePriority: $tubePriority,
             tube: $tube,
-            reserveTimeout: $reserveTimeout,
-            consumeAll: $consumeAll
+            reserveTimeout: $reserveTimeout
         );
 
         $expectedArray = [
@@ -76,7 +70,6 @@ final class BeanstalkCreateInfoTest extends TestCase
             'tube_priority' => $tubePriority,
             'tube' => $tube,
             'reserve_timeout' => $reserveTimeout,
-            'consume_all' => $consumeAll,
         ];
 
         $this->assertEquals($expectedArray, $beanstalkCreateInfo->toArray());


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bugfix?       | ❌
| Breaks BC?    | Don't think so
| New feature?  | ❌
| Issues        |  n/a
| Docs PR       | 

The `consume_all` parameter was removed a long time ago and serves no purpose in the v4 version of RoadRunner PHP.

See https://github.com/roadrunner-server/jobs/pull/135


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Streamlined class interfaces for `AMQPCreateInfo` and `BeanstalkCreateInfo` by removing the `consumeAll` functionality.
  
- **Bug Fixes**
	- Updated tests to reflect the removal of `consumeAll` assertions in both `AMQPCreateInfoTest` and `BeanstalkCreateInfoTest`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->