### PR TITLE
This PR fixes a few deprecation warnings thrown when used with PHP 8.4

### DIFF
--- a/src/Consumer.php
+++ b/src/Consumer.php
@@ -38,8 +38,8 @@ final class Consumer implements ConsumerInterface
     private readonly ReceivedTaskFactoryInterface $receivedTaskFactory;
 
     public function __construct(
-        WorkerInterface $worker = null,
-        ReceivedTaskFactoryInterface $receivedTaskFactory = null,
+        ?WorkerInterface $worker = null,
+        ?ReceivedTaskFactoryInterface $receivedTaskFactory = null,
     ) {
         $this->worker = $worker ?? Worker::create();
         $this->receivedTaskFactory = $receivedTaskFactory ?? new ReceivedTaskFactory($this->worker);

--- a/src/Queue.php
+++ b/src/Queue.php
@@ -72,7 +72,7 @@ final class Queue implements QueueInterface
     public function push(
         string $name,
         string|\Stringable $payload,
-        OptionsInterface $options = null,
+        ?OptionsInterface $options = null,
     ): QueuedTaskInterface {
         return $this->dispatch(
             $this->create($name, $payload, $options),
@@ -87,7 +87,7 @@ final class Queue implements QueueInterface
     public function create(
         string $name,
         string|\Stringable $payload,
-        OptionsInterface $options = null,
+        ?OptionsInterface $options = null,
     ): PreparedTaskInterface {
         if ($this->options !== null && \method_exists($this->options, 'mergeOptional')) {
             /** @var OptionsInterface $options */

--- a/src/QueueInterface.php
+++ b/src/QueueInterface.php
@@ -46,7 +46,7 @@ interface QueueInterface
     public function create(
         string $name,
         string|\Stringable $payload,
-        OptionsInterface $options = null,
+        ?OptionsInterface $options = null,
     ): PreparedTaskInterface;
 
     /**

--- a/src/Task/PreparedTask.php
+++ b/src/Task/PreparedTask.php
@@ -25,7 +25,7 @@ final class PreparedTask extends Task implements PreparedTaskInterface, OptionsA
     public function __construct(
         string $name,
         string|\Stringable $payload,
-        OptionsInterface $options = null,
+        ?OptionsInterface $options = null,
         array $headers = [],
     ) {
         $this->options = $options ?? new Options();


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bugfix?       | ❌
| Breaks BC?    | ❌ <!-- please update "xxx Impact Changes" section in CHANGELOG.md file -->
| New feature?  | ✔️ <!-- please update "Other Features" section in CHANGELOG.md file -->
| Issues        | N/A <!-- prefix each issue number with "#" symbol, no need to create an issue if none exist, explain below instead -->
| Docs PR       | N/A <!-- prefix each issue number with "spiral/docs#", required only for new features -->

When using this library with PHP 8.4, I noticed some deprecation warnings like this:

`Deprecated: Spiral\RoadRunner\Jobs\Consumer::__construct(): Implicitly marking parameter $receivedTaskFactory as nullable is deprecated, the explicit nullable type must be used instead`

This is due to this change https://wiki.php.net/rfc/deprecate-implicitly-nullable-types, in which initializing a method argument with value `null` is deprecated if the type is not explicitly nullable.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced flexibility in method parameters across multiple classes, allowing for nullable options.
  
- **Bug Fixes**
	- Improved type safety in constructors and method signatures, ensuring more robust handling of optional parameters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->