### PR TITLE
feature: add ackwait config

### DIFF
--- a/src/Queue/Kafka/ConsumerOffset.php
+++ b/src/Queue/Kafka/ConsumerOffset.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Spiral\RoadRunner\Jobs\Queue\Kafka;
 
-final class ConsumerOffset implements \JsonSerializable
+class ConsumerOffset implements \JsonSerializable
 {
     /**
      * @param int<0,max>|null $value

--- a/src/Queue/Kafka/ConsumerOffset.php
+++ b/src/Queue/Kafka/ConsumerOffset.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Spiral\RoadRunner\Jobs\Queue\Kafka;
 
-class ConsumerOffset implements \JsonSerializable
+final class ConsumerOffset implements \JsonSerializable
 {
     /**
      * @param int<0,max>|null $value

--- a/src/Queue/NatsCreateInfo.php
+++ b/src/Queue/NatsCreateInfo.php
@@ -15,6 +15,7 @@ final class NatsCreateInfo extends CreateInfo
     public const DELETE_STREAM_ON_STOP_DEFAULT_VALUE = false;
     public const DELETE_AFTER_ACK_DEFAULT_VALUE = false;
     public const PRIORITY_DEFAULT_VALUE = 2;
+    public const ACK_WAIT_DEFAULT_VALUE = 0;
 
     /**
      * @param non-empty-string $name
@@ -23,6 +24,7 @@ final class NatsCreateInfo extends CreateInfo
      * @param positive-int $priority
      * @param positive-int $prefetch
      * @param positive-int $rateLimit
+     * @param int<0, max> $ackWait
      */
     public function __construct(
         string $name,
@@ -34,6 +36,7 @@ final class NatsCreateInfo extends CreateInfo
         public readonly int $rateLimit = self::RATE_LIMIT_DEFAULT_VALUE,
         public readonly bool $deleteStreamOnStop = self::DELETE_STREAM_ON_STOP_DEFAULT_VALUE,
         public readonly bool $deleteAfterAck = self::DELETE_AFTER_ACK_DEFAULT_VALUE,
+        public readonly bool $ackWait = self::ACK_WAIT_DEFAULT_VALUE,
     ) {
         parent::__construct(Driver::NATS, $name, $priority);
 
@@ -41,6 +44,7 @@ final class NatsCreateInfo extends CreateInfo
         \assert($rateLimit >= 1, 'Precondition [rateLimit >= 1] failed');
         \assert($subject !== '', 'Precondition [subject !== ""] failed');
         \assert($stream !== '', 'Precondition [stream !== ""] failed');
+        \assert($ackWait >= 0, 'Precondition [ackWait >= 0] failed');
     }
 
     public function toArray(): array
@@ -53,6 +57,7 @@ final class NatsCreateInfo extends CreateInfo
             'stream' => $this->stream,
             'delete_stream_on_stop' => $this->deleteStreamOnStop,
             'delete_after_ack' => $this->deleteAfterAck,
+            'ack_wait' => $this->ackWait,
         ]);
     }
 }

--- a/src/Queue/NatsCreateInfo.php
+++ b/src/Queue/NatsCreateInfo.php
@@ -36,7 +36,7 @@ final class NatsCreateInfo extends CreateInfo
         public readonly int $rateLimit = self::RATE_LIMIT_DEFAULT_VALUE,
         public readonly bool $deleteStreamOnStop = self::DELETE_STREAM_ON_STOP_DEFAULT_VALUE,
         public readonly bool $deleteAfterAck = self::DELETE_AFTER_ACK_DEFAULT_VALUE,
-        public readonly bool $ackWait = self::ACK_WAIT_DEFAULT_VALUE,
+        public readonly int $ackWait = self::ACK_WAIT_DEFAULT_VALUE,
     ) {
         parent::__construct(Driver::NATS, $name, $priority);
 

--- a/tests/Unit/Queue/NatsCreateInfoTest.php
+++ b/tests/Unit/Queue/NatsCreateInfoTest.php
@@ -21,7 +21,8 @@ final class NatsCreateInfoTest extends TestCase
             false,
             300,
             true,
-            true
+            true,
+            0
         );
 
         $this->assertSame(Driver::NATS, $natsCreateInfo->driver);
@@ -34,6 +35,7 @@ final class NatsCreateInfoTest extends TestCase
         $this->assertSame(300, $natsCreateInfo->rateLimit);
         $this->assertTrue($natsCreateInfo->deleteStreamOnStop);
         $this->assertTrue($natsCreateInfo->deleteAfterAck);
+        $this->assertTrue($natsCreateInfo->ackWait);
     }
 
     public function testToArray(): void
@@ -47,7 +49,8 @@ final class NatsCreateInfoTest extends TestCase
             false,
             300,
             true,
-            true
+            true,
+            0
         );
 
         $expectedArray = [
@@ -61,6 +64,7 @@ final class NatsCreateInfoTest extends TestCase
             'stream' => 'test_stream',
             'delete_stream_on_stop' => true,
             'delete_after_ack' => true,
+            'ack_wait' => 0,
         ];
 
         $this->assertSame($expectedArray, $natsCreateInfo->toArray());

--- a/tests/Unit/Queue/NatsCreateInfoTest.php
+++ b/tests/Unit/Queue/NatsCreateInfoTest.php
@@ -35,7 +35,7 @@ final class NatsCreateInfoTest extends TestCase
         $this->assertSame(300, $natsCreateInfo->rateLimit);
         $this->assertTrue($natsCreateInfo->deleteStreamOnStop);
         $this->assertTrue($natsCreateInfo->deleteAfterAck);
-        $this->assertTrue($natsCreateInfo->ackWait);
+        $this->assertSame(0, $natsCreateInfo->ackWait);
     }
 
     public function testToArray(): void


### PR DESCRIPTION
related to roadrunner-server [#190](https://github.com/roadrunner-server/nats/pull/190)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * NATS queue creation gains a configurable ack-wait time (defaults to 0), validated as non-negative and included in serialized output.
* **Tests**
  * Unit tests updated to verify the new ack-wait property and its serialized representation.
* **Refactor**
  * Kafka consumer offset class made final to clarify its intended usage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->